### PR TITLE
Fix CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # compile_flags.txt is for clangd
-CXXFLAGS += -Wall -Wextra -Wpedantic -Wno-unused-parameter $(shell cat compile_flags.txt) -MMD
+CXXFLAGS += -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-deprecated-declarations $(shell cat compile_flags.txt) -MMD
 LDFLAGS += -lncursesw     # needs cursesw instead of curses for unicodes
 IWYU ?= iwyu
 

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -10,10 +10,10 @@ doesn't support --, but nobody needs it for this program imo
 #include <cstddef>
 #include <deque>
 #include <iomanip>
-#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 enum class OptionType { YESNO, INT };

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -14,7 +14,6 @@ doesn't support --, but nobody needs it for this program imo
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <vector>
 
 enum class OptionType { YESNO, INT };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,6 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Fixes #17 by silencing the deprecation warning. It's not ideal, but nothing is ideal in C++ anyway so I don't care.

Also deletes includes that newer iwyu realizes are unnecessary.