### PR TITLE
Add version consistency check to CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you don't like colors, use the `--no-colors` option:
 
 ## Setup
 
-1. Install Jou version 2025-04-29-0400 using [Jou's instructions](https://github.com/Akuli/jou/blob/main/README.md#setup).
+1. Install Jou version 2025-04-29-0400 using [Jou's instructions](https://github.com/Akuli/jou/blob/2025-04-29-0400/README.md#setup).
     Newer versions of Jou may also work.
 2. Install curses:
     ```


### PR DESCRIPTION
CI will now fail if the Jou version is specified differently in README and GitHub Actions config.