### PR TITLE
Fix typo in .github/workflows/main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Check that Jou version is specified consistently
       run: |
-        n=$(grep -o "$${{ steps.extract-version.outputs.JOU_VERSION }}" README.md | tee /dev/stderr | wc -l)
+        n=$(grep -o "${{ steps.extract-version.outputs.JOU_VERSION }}" README.md | tee /dev/stderr | wc -l)
         if [ $n != 2 ]; then
           echo "Error: README should mention jou version twice"
           exit 1


### PR DESCRIPTION
With the typo, it still works, because it searches for the version number without its first character because $2 happens to be empty in the bash session.